### PR TITLE
externalize prompts into markdown templates

### DIFF
--- a/root/src/core/parsers.ts
+++ b/root/src/core/parsers.ts
@@ -124,14 +124,11 @@ export async function parseCity(
     const uniqueCities = [...new Set(potentialCities)];
     
     if (uniqueCities.length > 0) {
-      const prompt = `Extract the most likely city name from this text. Return JSON with city and confidence (0-1).
-
-Text: "${text}"
-Context: ${context ? JSON.stringify(context) : '{}'}
-
-Potential city candidates: ${JSON.stringify(uniqueCities)}
-
-Return only valid JSON with "city" and "confidence" fields.`;
+      const tpl = await getPrompt('city_name_extractor');
+      const prompt = tpl
+        .replace('{text}', text)
+        .replace('{context}', context ? JSON.stringify(context) : '{}')
+        .replace('{candidates}', JSON.stringify(uniqueCities));
 
       const raw = await callLLM(prompt, { responseFormat: 'json', log: logger });
       const json = JSON.parse(raw);
@@ -533,16 +530,10 @@ export async function parseOriginDestination(
 
   // LLM fallback
   try {
-    const prompt = `Extract origin and destination cities from this text. Return JSON with originCity and destinationCity fields (null if not found) and confidence (0-1).
-
-Text: "${text}"
-Context: ${context ? JSON.stringify(context) : '{}'}
-
-Look for patterns like:
-- "from X" or "leaving X" = origin
-- "to Y" or "in Y" = destination
-
-Return only valid JSON.`;
+    const tpl = await getPrompt('origin_destination_extractor');
+    const prompt = tpl
+      .replace('{text}', text)
+      .replace('{context}', context ? JSON.stringify(context) : '{}');
 
     const raw = await callLLM(prompt, { responseFormat: 'json', log: logger });
     const json = JSON.parse(raw);

--- a/root/src/core/prompts.ts
+++ b/root/src/core/prompts.ts
@@ -26,7 +26,22 @@ type PromptName =
   | 'search_extract_country'
   | 'search_extract_attractions'
   | 'complexity_assessor'
-  | 'iata_code_generator';
+  | 'iata_code_generator'
+  | 'flight_complexity_detector'
+  | 'policy_summarizer'
+  | 'policy_classifier'
+  | 'search_result_extractor'
+  | 'search_query_optimizer_llm'
+  | 'preference_extractor'
+  | 'attractions_kid_friendly'
+  | 'city_name_extractor'
+  | 'origin_destination_extractor'
+  | 'attractions_summarizer'
+  | 'country_disambiguator'
+  | 'crawlee_page_summary'
+  | 'crawlee_overall_summary'
+  | 'destinations_recommender'
+  | 'llm_test_evaluator';
 
 let loaded = false;
 const PROMPTS: Partial<Record<PromptName, string>> = {};
@@ -103,6 +118,51 @@ export async function preloadPrompts(): Promise<void> {
   );
   PROMPTS.complexity_assessor = await loadFileSafe(
     path.join(base, 'complexity_assessor.md'),
+  );
+  PROMPTS.flight_complexity_detector = await loadFileSafe(
+    path.join(base, 'flight_complexity_detector.md'),
+  );
+  PROMPTS.policy_summarizer = await loadFileSafe(
+    path.join(base, 'policy_summarizer.md'),
+  );
+  PROMPTS.policy_classifier = await loadFileSafe(
+    path.join(base, 'policy_classifier.md'),
+  );
+  PROMPTS.search_result_extractor = await loadFileSafe(
+    path.join(base, 'search_result_extractor.md'),
+  );
+  PROMPTS.search_query_optimizer_llm = await loadFileSafe(
+    path.join(base, 'search_query_optimizer_llm.md'),
+  );
+  PROMPTS.preference_extractor = await loadFileSafe(
+    path.join(base, 'preference_extractor.md'),
+  );
+  PROMPTS.attractions_kid_friendly = await loadFileSafe(
+    path.join(base, 'attractions_kid_friendly.md'),
+  );
+  PROMPTS.city_name_extractor = await loadFileSafe(
+    path.join(base, 'city_name_extractor.md'),
+  );
+  PROMPTS.origin_destination_extractor = await loadFileSafe(
+    path.join(base, 'origin_destination_extractor.md'),
+  );
+  PROMPTS.attractions_summarizer = await loadFileSafe(
+    path.join(base, 'attractions_summarizer.md'),
+  );
+  PROMPTS.country_disambiguator = await loadFileSafe(
+    path.join(base, 'country_disambiguator.md'),
+  );
+  PROMPTS.crawlee_page_summary = await loadFileSafe(
+    path.join(base, 'crawlee_page_summary.md'),
+  );
+  PROMPTS.crawlee_overall_summary = await loadFileSafe(
+    path.join(base, 'crawlee_overall_summary.md'),
+  );
+  PROMPTS.destinations_recommender = await loadFileSafe(
+    path.join(base, 'destinations_recommender.md'),
+  );
+  PROMPTS.llm_test_evaluator = await loadFileSafe(
+    path.join(base, 'llm_test_evaluator.md'),
   );
   loaded = true;
 }

--- a/root/src/core/router.ts
+++ b/root/src/core/router.ts
@@ -19,31 +19,8 @@ async function isDirectFlightQuery(message: string, logger?: any): Promise<{
   reasoning: string;
 }> {
   try {
-    const prompt = `Analyze this flight-related query and determine if it's a DIRECT flight search or COMPLEX travel planning.
-
-DIRECT flight search characteristics:
-- Specific origin and destination mentioned
-- Clear travel dates or timeframe
-- Focused on finding/booking flights
-- Examples: "flights from NYC to London in March", "book flight Moscow to Tel Aviv October", "find flights Paris to Tokyo next week"
-
-COMPLEX travel planning characteristics:
-- Multiple constraints (budget, family needs, preferences)
-- Seeking recommendations or ideas
-- Multiple travel components (hotels, activities, etc.)
-- Examples: "From NYC, end of June, 4-5 days, 2 adults + toddler, budget $2.5k, ideas?", "family trip to Europe with elderly parents, need short flights"
-
-Query: "${message}"
-
-Return JSON with:
-- isDirect: true/false
-- confidence: 0.0-1.0 (how certain you are)
-- reasoning: brief explanation
-
-Examples:
-"flights from moscow to tel aviv in october" → {"isDirect": true, "confidence": 0.95, "reasoning": "Clear origin, destination, and timeframe specified"}
-"From NYC, end of June, 4-5 days, 2 adults + toddler, budget $2.5k, ideas?" → {"isDirect": false, "confidence": 0.9, "reasoning": "Complex planning with multiple constraints and seeking ideas"}`;
-
+    const tpl = await getPrompt('flight_complexity_detector');
+    const prompt = tpl.replace('{message}', message);
     const response = await callLLM(prompt, { responseFormat: 'json', log: logger });
     const parsed = JSON.parse(response);
     

--- a/root/src/core/transformers-attractions-classifier.ts
+++ b/root/src/core/transformers-attractions-classifier.ts
@@ -1,5 +1,6 @@
 import { classifyContent } from './transformers-classifier.js';
 import type pino from 'pino';
+import { getPrompt } from './prompts.js';
 
 export interface AttractionClassification {
   isKidFriendly: boolean;
@@ -81,16 +82,9 @@ async function classifyAttraction(
     
     // Step 2: Fallback to LLM if NLP confidence is low
     const { callLLM } = await import('./llm.js');
-    
-    const prompt = `Is this attraction suitable for families with children? Respond with JSON:
-"${text}"
 
-{
-  "isKidFriendly": true/false,
-  "categories": ["family", "educational", "cultural", "nature", "entertainment"],
-  "confidence": 0.0-1.0,
-  "reasoning": "brief explanation"
-}`;
+    const tpl = await getPrompt('attractions_kid_friendly');
+    const prompt = tpl.replace('{text}', text);
 
     const response = await callLLM(prompt, { responseFormat: 'json', log });
     const parsed = JSON.parse(response);

--- a/root/src/prompts/attractions_kid_friendly.md
+++ b/root/src/prompts/attractions_kid_friendly.md
@@ -1,0 +1,9 @@
+Is this attraction suitable for families with children? Respond with JSON:
+"{text}"
+
+{
+  "isKidFriendly": true/false,
+  "categories": ["family", "educational", "cultural", "nature", "entertainment"],
+  "confidence": 0.0-1.0,
+  "reasoning": "brief explanation"
+}

--- a/root/src/prompts/attractions_summarizer.md
+++ b/root/src/prompts/attractions_summarizer.md
@@ -1,0 +1,11 @@
+Summarize these attractions in {city} for travelers. {profileContext}
+
+Attractions:
+{attractions}
+
+Create a natural, engaging summary that highlights the key attractions. Be
+concise but informative. Return JSON:
+
+{
+  "summary": "Natural paragraph describing the attractions with their key features"
+}

--- a/root/src/prompts/city_name_extractor.md
+++ b/root/src/prompts/city_name_extractor.md
@@ -1,0 +1,9 @@
+Extract the most likely city name from this text. Return JSON with city and
+confidence (0-1).
+
+Text: "{text}"
+Context: {context}
+
+Potential city candidates: {candidates}
+
+Return only valid JSON with "city" and "confidence" fields.

--- a/root/src/prompts/country_disambiguator.md
+++ b/root/src/prompts/country_disambiguator.md
@@ -1,0 +1,16 @@
+Analyze this location name and determine if it refers to a country or city/region:
+
+Location: "{target}"
+
+Consider context clues like:
+- "Georgia travel" → country (not US state)
+- "Paris vacation" → city
+- "UK visa" → country
+- "New York attractions" → city
+
+Respond with JSON:
+{
+  "isCountry": boolean,
+  "resolvedName": "standardized name",
+  "confidence": 0.0-1.0
+}

--- a/root/src/prompts/crawlee_overall_summary.md
+++ b/root/src/prompts/crawlee_overall_summary.md
@@ -1,0 +1,7 @@
+Create a comprehensive 2-3 paragraph summary based on these webpage summaries for
+the query: "{query}"
+
+Summaries:
+{summaries}
+
+Comprehensive Summary:

--- a/root/src/prompts/crawlee_page_summary.md
+++ b/root/src/prompts/crawlee_page_summary.md
@@ -1,0 +1,6 @@
+Summarize this webpage content in 2-3 sentences, focusing on information
+relevant to: "{query}"
+
+Content: {content}
+
+Summary:

--- a/root/src/prompts/destinations_recommender.md
+++ b/root/src/prompts/destinations_recommender.md
@@ -1,0 +1,19 @@
+Based on the following travel preferences, recommend 3-4 destinations.
+Preferences: {preferences}
+User query context: {slots}
+
+For each destination, provide a brief, compelling reason why it matches the
+preferences. Return the recommendations in a JSON array with the following
+structure:
+[
+  {
+    "city": "City Name",
+    "country": "Country Name",
+    "description": "Why this destination is a good fit.",
+    "tags": {
+      "climate": "e.g., warm, cold, temperate",
+      "budget": "e.g., low, mid, high",
+      "family_friendly": true/false
+    }
+  }
+]

--- a/root/src/prompts/flight_complexity_detector.md
+++ b/root/src/prompts/flight_complexity_detector.md
@@ -1,0 +1,30 @@
+Analyze this flight-related query and determine if it's a DIRECT flight search or
+COMPLEX travel planning.
+
+DIRECT flight search characteristics:
+- Specific origin and destination mentioned
+- Clear travel dates or timeframe
+- Focused on finding/booking flights
+- Examples: "flights from NYC to London in March", "book flight Moscow to Tel Aviv October",
+  "find flights Paris to Tokyo next week"
+
+COMPLEX travel planning characteristics:
+- Multiple constraints (budget, family needs, preferences)
+- Seeking recommendations or ideas
+- Multiple travel components (hotels, activities, etc.)
+- Examples: "From NYC, end of June, 4-5 days, 2 adults + toddler, budget $2.5k, ideas?",
+  "family trip to Europe with elderly parents, need short flights"
+
+Query: "{message}"
+
+Return JSON with:
+- isDirect: true/false
+- confidence: 0.0-1.0 (how certain you are)
+- reasoning: brief explanation
+
+Examples:
+"flights from moscow to tel aviv in october" -> {"isDirect": true, "confidence": 0.95,
+"reasoning": "Clear origin, destination, and timeframe specified"}
+"From NYC, end of June, 4-5 days, 2 adults + toddler, budget $2.5k, ideas?" ->
+{"isDirect": false, "confidence": 0.9,
+"reasoning": "Complex planning with multiple constraints and seeking ideas"}

--- a/root/src/prompts/llm_test_evaluator.md
+++ b/root/src/prompts/llm_test_evaluator.md
@@ -1,0 +1,13 @@
+You are a test evaluator. Evaluate if the actual response meets the expected
+criteria.
+
+TEST: {testDescription}
+ACTUAL RESPONSE: {actualResponse}
+EXPECTED CRITERIA: {expectedCriteria}
+
+Return ONLY valid JSON (no markdown formatting):
+{
+  "passes": true/false,
+  "confidence": 0.0-1.0,
+  "reason": "brief explanation"
+}

--- a/root/src/prompts/origin_destination_extractor.md
+++ b/root/src/prompts/origin_destination_extractor.md
@@ -1,0 +1,11 @@
+Extract origin and destination cities from this text. Return JSON with
+originCity and destinationCity fields (null if not found) and confidence (0-1).
+
+Text: "{text}"
+Context: {context}
+
+Look for patterns like:
+- "from X" or "leaving X" = origin
+- "to Y" or "in Y" = destination
+
+Return only valid JSON.

--- a/root/src/prompts/policy_classifier.md
+++ b/root/src/prompts/policy_classifier.md
@@ -1,0 +1,10 @@
+Classify this travel policy question into one of three categories:
+
+Question: "{question}"
+
+Categories:
+- airlines: Flight policies, baggage, airline-specific rules, boarding, seats, miles
+- hotels: Hotel policies, room bookings, check-in/out, hotel-specific rules
+- visas: Visa requirements, passport rules, immigration, entry requirements
+
+Respond with only: airlines, hotels, or visas

--- a/root/src/prompts/policy_summarizer.md
+++ b/root/src/prompts/policy_summarizer.md
@@ -1,0 +1,16 @@
+Based on the following policy documents, provide a clear and concise answer to
+the user's question.
+
+Question: {question}
+
+Policy Documents:
+{context}
+
+Instructions:
+- Answer directly and concisely
+- Use information only from the provided documents
+- If the documents don't contain relevant information, say so
+- Include specific details like timeframes, fees, or requirements when available
+- Keep the response professional and helpful
+
+Answer:

--- a/root/src/prompts/preference_extractor.md
+++ b/root/src/prompts/preference_extractor.md
@@ -1,0 +1,11 @@
+Analyze this travel request and extract preferences in JSON format:
+"{text}"
+
+Return JSON with these fields (use null if not clear):
+{
+  "travelStyle": "family|romantic|adventure|cultural|business|budget|luxury",
+  "budgetLevel": "low|mid|high",
+  "activityType": "museums|nature|nightlife|shopping|food|history",
+  "groupType": "solo|couple|family|friends|business",
+  "confidence": 0.0-1.0
+}

--- a/root/src/prompts/search_query_optimizer_llm.md
+++ b/root/src/prompts/search_query_optimizer_llm.md
@@ -1,0 +1,14 @@
+Optimize this search query for better web search results. Return JSON:
+
+Original query: "{query}"
+Context: {context}
+
+Analyze the query intent and optimize it for web search engines. Add relevant
+keywords, improve specificity, and structure for better results.
+
+{
+  "optimizedQuery": "enhanced search query with relevant keywords",
+  "queryType": "weather|attractions|destinations|country|general",
+  "confidence": 0.0-1.0,
+  "reasoning": "brief explanation of optimization"
+}

--- a/root/src/prompts/search_result_extractor.md
+++ b/root/src/prompts/search_result_extractor.md
@@ -1,0 +1,13 @@
+Extract relevant information from these search results for: "{query}"
+
+Search Results:
+{results}
+
+Extract the most relevant information for a {extractionType} query. Return JSON:
+
+{
+  "summary": "concise summary of relevant information",
+  "confidence": 0.0-1.0,
+  "entities": [{"text": "entity", "type": "type", "value": "normalized_value"}],
+  "relevanceScore": 0.0-1.0
+}

--- a/root/src/test/llm-evaluator.ts
+++ b/root/src/test/llm-evaluator.ts
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import { fetch } from 'undici';
+import { getPrompt } from '../core/prompts.js';
 
 interface EvaluationResult {
   passes: boolean;
@@ -18,20 +19,13 @@ export async function evaluateWithLLM(
   actualResponse: string,
   expectedCriteria: string
 ): Promise<EvaluationResult> {
-  const prompt = `You are a test evaluator. Evaluate if the actual response meets the expected criteria.
-
-TEST: ${testDescription}
-ACTUAL RESPONSE: ${actualResponse}
-EXPECTED CRITERIA: ${expectedCriteria}
-
-Return ONLY valid JSON (no markdown formatting):
-{
-  "passes": true/false,
-  "confidence": 0.0-1.0,
-  "reason": "brief explanation"
-}`;
-
   try {
+    const tpl = await getPrompt('llm_test_evaluator');
+    const prompt = tpl
+      .replace('{testDescription}', testDescription)
+      .replace('{actualResponse}', actualResponse)
+      .replace('{expectedCriteria}', expectedCriteria);
+
     const baseUrl = process.env.LLM_TEST_EVALUATION_MODEL_BASEURL;
     const apiKey = process.env.LLM_TEST_EVALUATION_MODEL_API_KEY;
     const model = process.env.LLM_TEST_EVALUATION_MODEL;

--- a/root/src/tools/crawlee_research.ts
+++ b/root/src/tools/crawlee_research.ts
@@ -1,4 +1,5 @@
 import { callLLM } from '../core/llm.js';
+import { getPrompt } from '../core/prompts.js';
 
 type CrawlResult = {
   url: string;
@@ -238,11 +239,10 @@ function extractMainContent($: any): string {
 }
 
 async function summarizePage(content: string, query: string): Promise<string> {
-  const prompt = `Summarize this webpage content in 2-3 sentences, focusing on information relevant to: "${query}"
-
-Content: ${content.slice(0, 1500)}
-
-Summary:`;
+  const tpl = await getPrompt('crawlee_page_summary');
+  const prompt = tpl
+    .replace('{query}', query)
+    .replace('{content}', content.slice(0, 1500));
 
   try {
     const response = await callLLM(prompt);
@@ -257,12 +257,10 @@ async function createOverallSummary(results: CrawlResult[], query: string): Prom
   
   const summaries = results.map((r, i) => `[${i + 1}] ${r.title}: ${r.summary}`).join('\n');
   
-  const prompt = `Create a comprehensive 2-3 paragraph summary based on these webpage summaries for the query: "${query}"
-
-Summaries:
-${summaries}
-
-Comprehensive Summary:`;
+  const tpl = await getPrompt('crawlee_overall_summary');
+  const prompt = tpl
+    .replace('{query}', query)
+    .replace('{summaries}', summaries);
 
   try {
     const response = await callLLM(prompt);


### PR DESCRIPTION
## Summary
- load flight complexity and other prompts from markdown files
- add prompt loader entries for new templates
- replace inline prompt strings across core, tool, and test modules

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: connect ENETUNREACH 140.82.113.4:443)*

------
https://chatgpt.com/codex/tasks/task_e_68c1ba47f4fc8324b68544b7da628b3d